### PR TITLE
Convert Skybox pano example to WebVR

### DIFF
--- a/three.js-dev/examples/canvas_geometry_panorama.html
+++ b/three.js-dev/examples/canvas_geometry_panorama.html
@@ -105,8 +105,8 @@
 
 			function onWindowResize() {
 
-				camera.aspect = window.innerWidth / window.innerHeight;
-				camera.updateProjectionMatrix();
+				// camera.aspect = window.innerWidth / window.innerHeight;
+				// camera.updateProjectionMatrix();
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
@@ -163,11 +163,11 @@
 
 			function onDocumentMouseWheel( event ) {
 
-				var fov = camera.fov + event.deltaY * 0.05;
+				// var fov = camera.fov + event.deltaY * 0.05;
 
-				camera.fov = THREE.Math.clamp( fov, 10, 75 );
+				// camera.fov = THREE.Math.clamp( fov, 10, 75 );
 
-				camera.updateProjectionMatrix();
+				// camera.updateProjectionMatrix();
 
 			}
 
@@ -210,7 +210,7 @@
 
 			function update() {
 
-				if ( isUserInteracting === false ) {
+				/* if ( isUserInteracting === false ) {
 
 					lon += 0.1;
 
@@ -224,7 +224,7 @@
 				target.y = 500 * Math.cos( phi );
 				target.z = 500 * Math.sin( phi ) * Math.sin( theta );
 
-				camera.lookAt( target );
+				camera.lookAt( target ); */
 
 				renderer.render( scene, camera );
 

--- a/three.js-dev/examples/canvas_geometry_panorama.html
+++ b/three.js-dev/examples/canvas_geometry_panorama.html
@@ -230,6 +230,20 @@
 
 			}
 
+      if (navigator.getVRDisplays) {
+        navigator.getVRDisplays()
+          .then(displays => {
+            const presentingDisplay = displays.find(display => display.isPresenting);
+            if (presentingDisplay) {
+              renderer.vr.enabled = true;
+              renderer.vr.setDevice(presentingDisplay);
+            }
+          })
+          .catch(err => {
+            console.warn(err);
+          });
+      }
+
 		</script>
 	</body>
 </html>

--- a/three.js-dev/examples/canvas_geometry_panorama.html
+++ b/three.js-dev/examples/canvas_geometry_panorama.html
@@ -34,9 +34,6 @@
 
 		<script src="../build/three.js"></script>
 
-		<script src="js/renderers/Projector.js"></script>
-		<script src="js/renderers/CanvasRenderer.js"></script>
-
 		<script>
 
 			var camera, scene, renderer;
@@ -87,7 +84,7 @@
 				mesh = new THREE.Mesh( geometry, materials );
 				scene.add( mesh );
 
-				renderer = new THREE.CanvasRenderer();
+				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );


### PR DESCRIPTION
This converts https://threejs.org/examples/#canvas_geometry_panorama to use WebGL and WebVR so it's loadable as an Exokit reality tab layer.

Camera twiddling commented because it stole the camera from the user's head for automatic spin 🤢.

![capture 3](https://user-images.githubusercontent.com/6926057/40536829-598d85f0-5fdb-11e8-93f3-b0b560f0c3a4.PNG)

